### PR TITLE
🐛 Thread Safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,12 @@ This PROS template aims to simplify interactions with devices, and implement a c
 ## Features
 
  - [X] [Unitized](https://github.com/LemLib/units)
+ - [X] thread-safe
  - [X] Advanced Error Handling
  - [ ] Device disconnect/reconnect callbacks
  - [X] Compile-time Port Checks
 
- - [X] **Motor**
+ - [ ] **Motor**
    - [X] Changing encoder units don't affect reported angle
    - [X] Current limit
    - [X] Differentiate 11W and 5.5W motors
@@ -37,20 +38,20 @@ This PROS template aims to simplify interactions with devices, and implement a c
    - [ ] Support for all VEX color sensors
      - [ ] V5 Optical Sensor
 
- - [X] **Abstract Encoders**
+ - [ ] **Abstract Encoders**
    - [X] Generic interface for any encoder
-     - [X] Support for all VEX encoders
-       - [X] Motors / Motor Groups
-       - [X] V5 Rotation Sensor
-       - [X] Optical Shaft encoder
-       - [ ] ADI Potentiometer V1
-       - [ ] ADI Potentiometer V2
+   - [X] Support for all VEX encoders
+     - [X] Motors / Motor Groups
+     - [X] V5 Rotation Sensor
+     - [X] Optical Shaft encoder
+     - [ ] ADI Potentiometer V1
+     - [ ] ADI Potentiometer V2
 
- - [X] **Abstract Gyro**
-   - [X] Generic interface for any gyro
-   - [X] Gyro Scaling
+ - [ ] **Abstract Gyro**
+   - [ ] Generic interface for any gyro
+   - [ ] Gyro Scaling
    - [ ] Support for all VEX gyros
-     - [X] V5 Inertial Sensor
+     - [ ] V5 Inertial Sensor
      - [ ] V5 GPS Sensor
      - [ ] ADI analog gyro
 
@@ -62,9 +63,10 @@ This PROS template aims to simplify interactions with devices, and implement a c
      - [ ] ADI Accelerometer
 
  - [ ] **Abstract IMU**
-   - [ ] Generic interface for any IMU
+   - [X] Generic interface for any IMU
+   - [X] Gyro Scaling
    - [ ] Support for all VEX IMUs
-     - [ ] V5 Inertial Sensor
+     - [X] V5 Inertial Sensor
      - [ ] V5 GPS Sensor
 
 ## Who Should Use This?

--- a/include/hardware/Encoder/ADIEncoder.hpp
+++ b/include/hardware/Encoder/ADIEncoder.hpp
@@ -58,7 +58,6 @@ class ADIEncoder : public Encoder {
          * @endcode
          */
         ADIEncoder(SmartPort expanderPort, ADIPair ports, bool reversed);
-
         /**
          * @brief ADIEncoder copy constructor
          *
@@ -67,10 +66,7 @@ class ADIEncoder : public Encoder {
          *
          * @param other the ADIEncoder to copy
          */
-        ADIEncoder(ADIEncoder& other)
-            : m_encoder(other.m_encoder),
-              m_offset(other.m_offset) {}
-
+        ADIEncoder(ADIEncoder& other);
         /**
          * @brief whether the encoder is connected
          *

--- a/include/hardware/Encoder/ADIEncoder.hpp
+++ b/include/hardware/Encoder/ADIEncoder.hpp
@@ -59,6 +59,14 @@ class ADIEncoder : public Encoder {
          */
         ADIEncoder(SmartPort expanderPort, ADIPair ports, bool reversed);
 
+        /**
+         * @brief ADIEncoder copy constructor
+         *
+         * Because pros::Mutex does not have a copy constructor, an explicit
+         * copy constructor for the ADIEncoder is necessary
+         *
+         * @param other the ADIEncoder to copy
+         */
         ADIEncoder(ADIEncoder& other)
             : m_encoder(other.m_encoder),
               m_offset(other.m_offset) {}

--- a/include/hardware/Encoder/ADIEncoder.hpp
+++ b/include/hardware/Encoder/ADIEncoder.hpp
@@ -3,6 +3,7 @@
 #include "hardware/Encoder/Encoder.hpp"
 #include "hardware/Port.hpp"
 #include "pros/adi.hpp"
+#include "pros/rtos.hpp"
 
 namespace lemlib {
 /**
@@ -57,6 +58,11 @@ class ADIEncoder : public Encoder {
          * @endcode
          */
         ADIEncoder(SmartPort expanderPort, ADIPair ports, bool reversed);
+
+        ADIEncoder(ADIEncoder& other)
+            : m_encoder(other.m_encoder),
+              m_offset(other.m_offset) {}
+
         /**
          * @brief whether the encoder is connected
          *
@@ -130,6 +136,7 @@ class ADIEncoder : public Encoder {
          */
         int setAngle(Angle angle) override;
     private:
+        pros::Mutex m_mutex;
         pros::adi::Encoder m_encoder;
         Angle m_offset = 0_stDeg;
 };

--- a/include/hardware/Encoder/ADIEncoder.hpp
+++ b/include/hardware/Encoder/ADIEncoder.hpp
@@ -140,7 +140,7 @@ class ADIEncoder : public Encoder {
          */
         int setAngle(Angle angle) override;
     private:
-        pros::Mutex m_mutex;
+        mutable pros::Mutex m_mutex;
         pros::adi::Encoder m_encoder;
         Angle m_offset = 0_stDeg;
 };

--- a/include/hardware/Encoder/ADIEncoder.hpp
+++ b/include/hardware/Encoder/ADIEncoder.hpp
@@ -66,7 +66,7 @@ class ADIEncoder : public Encoder {
          *
          * @param other the ADIEncoder to copy
          */
-        ADIEncoder(ADIEncoder& other);
+        ADIEncoder(const ADIEncoder& other);
         /**
          * @brief whether the encoder is connected
          *

--- a/include/hardware/Encoder/V5RotationSensor.hpp
+++ b/include/hardware/Encoder/V5RotationSensor.hpp
@@ -168,7 +168,7 @@ class V5RotationSensor : public Encoder {
          */
         int setReversed(bool reversed);
     private:
-        pros::Mutex m_mutex;
+        mutable pros::Mutex m_mutex;
         Angle m_offset = 0_stRot;
         bool m_reversed;
         int m_port;

--- a/include/hardware/Encoder/V5RotationSensor.hpp
+++ b/include/hardware/Encoder/V5RotationSensor.hpp
@@ -33,7 +33,7 @@ class V5RotationSensor : public Encoder {
          *
          * @param other the V5RotationSensor to copy
          */
-        V5RotationSensor(V5RotationSensor& other);
+        V5RotationSensor(const V5RotationSensor& other);
         /**
          * @brief Create a new V5 Rotation Sensor
          *

--- a/include/hardware/Encoder/V5RotationSensor.hpp
+++ b/include/hardware/Encoder/V5RotationSensor.hpp
@@ -26,6 +26,15 @@ class V5RotationSensor : public Encoder {
          */
         V5RotationSensor(ReversibleSmartPort port);
         /**
+         * @brief V5RotationSensor copy constructor
+         *
+         * Because pros::Mutex does not have a copy constructor, an explicit
+         * copy constructor for the V5RotationSensor is necessary
+         *
+         * @param other the V5RotationSensor to copy
+         */
+        V5RotationSensor(V5RotationSensor& other);
+        /**
          * @brief Create a new V5 Rotation Sensor
          *
          * @param encoder the pros::Rotation object to use
@@ -159,6 +168,7 @@ class V5RotationSensor : public Encoder {
          */
         int setReversed(bool reversed);
     private:
+        pros::Mutex m_mutex;
         Angle m_offset = 0_stRot;
         bool m_reversed;
         int m_port;

--- a/include/hardware/IMU/V5InertialSensor.hpp
+++ b/include/hardware/IMU/V5InertialSensor.hpp
@@ -30,7 +30,7 @@ class V5InertialSensor : public IMU {
          *
          * @param other the V5InertialSensor to copy
          */
-        V5InertialSensor(V5InertialSensor& other);
+        V5InertialSensor(const V5InertialSensor& other);
         /**
          * @brief Create a new V5 Inertial Sensor
          *

--- a/include/hardware/IMU/V5InertialSensor.hpp
+++ b/include/hardware/IMU/V5InertialSensor.hpp
@@ -3,6 +3,7 @@
 #include "hardware/Port.hpp"
 #include "hardware/IMU/IMU.hpp"
 #include "pros/imu.hpp"
+#include "pros/rtos.hpp"
 
 namespace lemlib {
 class V5InertialSensor : public IMU {
@@ -21,6 +22,15 @@ class V5InertialSensor : public IMU {
          * @endcode
          */
         V5InertialSensor(SmartPort port);
+        /**
+         * @brief V5InertialSensor copy constructor
+         *
+         * Because pros::Mutex does not have a copy constructor, an explicit
+         * copy constructor is necessary
+         *
+         * @param other the V5InertialSensor to copy
+         */
+        V5InertialSensor(V5InertialSensor& other);
         /**
          * @brief Create a new V5 Inertial Sensor
          *
@@ -250,6 +260,7 @@ class V5InertialSensor : public IMU {
          */
         Number getGyroScalar() override;
     private:
+        pros::Mutex m_mutex;
         Angle m_offset = 0_stRot;
         pros::Imu m_imu;
 };

--- a/include/hardware/IMU/V5InertialSensor.hpp
+++ b/include/hardware/IMU/V5InertialSensor.hpp
@@ -260,7 +260,7 @@ class V5InertialSensor : public IMU {
          */
         Number getGyroScalar() override;
     private:
-        pros::Mutex m_mutex;
+        mutable pros::Mutex m_mutex;
         Angle m_offset = 0_stRot;
         pros::Imu m_imu;
 };

--- a/include/hardware/Motor/Motor.hpp
+++ b/include/hardware/Motor/Motor.hpp
@@ -505,7 +505,7 @@ class Motor : public Encoder {
          */
         AngularVelocity getOutputVelocity();
     private:
-        pros::Mutex m_mutex;
+        mutable pros::Mutex m_mutex;
         AngularVelocity m_outputVelocity;
         Angle m_offset = 0_stDeg;
         ReversibleSmartPort m_port;

--- a/include/hardware/Motor/Motor.hpp
+++ b/include/hardware/Motor/Motor.hpp
@@ -36,7 +36,7 @@ class Motor : public Encoder {
          *
          * @param other the Motor to copy
          */
-        Motor(Motor& other);
+        Motor(const Motor& other);
         /**
          * @brief Create a new Motor object
          *

--- a/include/hardware/Motor/Motor.hpp
+++ b/include/hardware/Motor/Motor.hpp
@@ -4,6 +4,7 @@
 #include "hardware/Encoder/Encoder.hpp"
 #include "hardware/Port.hpp"
 #include "units/Temperature.hpp"
+#include "pros/rtos.hpp"
 
 namespace lemlib {
 
@@ -27,6 +28,15 @@ class Motor : public Encoder {
          * @endcode
          */
         Motor(ReversibleSmartPort port, AngularVelocity outputVelocity);
+        /**
+         * @brief Motor copy constructor
+         *
+         * Because pros::Mutex does not have a copy constructor, an explicit
+         * copy constructor is necessary
+         *
+         * @param other the Motor to copy
+         */
+        Motor(Motor& other);
         /**
          * @brief Create a new Motor object
          *
@@ -479,7 +489,23 @@ class Motor : public Encoder {
          * @endcode
          */
         int setOutputVelocity(AngularVelocity outputVelocity);
+        /**
+         * @brief Get the output velocity of the motor
+         *
+         * @return AngularVelocity
+         *
+         * @b Example:
+         * @code {.cpp}
+         * void initialize() {
+         *     lemlib::Motor motor(1, 360_rpm);
+         *     // get the motor output
+         *     std::cout << motor.getOutputVelocity() << std::endl; // output: 360_rpm
+         * }
+         * @endcode
+         */
+        AngularVelocity getOutputVelocity();
     private:
+        pros::Mutex m_mutex;
         AngularVelocity m_outputVelocity;
         Angle m_offset = 0_stDeg;
         ReversibleSmartPort m_port;

--- a/include/hardware/Motor/MotorGroup.hpp
+++ b/include/hardware/Motor/MotorGroup.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "pros/motor_group.hpp"
+#include "pros/rtos.hpp"
 #include "hardware/Motor/Motor.hpp"
 #include "hardware/Port.hpp"
 #include "units/Angle.hpp"
@@ -38,6 +39,15 @@ class MotorGroup : public Encoder {
          * @endcode
          */
         MotorGroup(std::initializer_list<ReversibleSmartPort> ports, AngularVelocity outputVelocity);
+        /**
+         * @brief MotorGroup copy constructor
+         *
+         * Because pros::Mutex does not have a copy constructor, an explicit
+         * copy constructor is necessary
+         *
+         * @param other the MotorGroup to copy
+         */
+        MotorGroup(const MotorGroup& other);
         /**
          * @brief Create a new Motor Group
          *
@@ -177,7 +187,7 @@ class MotorGroup : public Encoder {
          * }
          * @endcode
          */
-        BrakeMode getBrakeMode();
+        BrakeMode getBrakeMode() const;
         /**
          * @brief whether any of the motors in the motor group are connected
          *
@@ -285,7 +295,7 @@ class MotorGroup : public Encoder {
          * }
          * @endcode
          */
-        Current getCurrentLimit();
+        Current getCurrentLimit() const;
         /**
          * @brief set the combined current limit of all motors in the group
          *
@@ -336,7 +346,7 @@ class MotorGroup : public Encoder {
          * }
          * @endcode
          */
-        std::vector<Temperature> getTemperatures();
+        std::vector<Temperature> getTemperatures() const;
         /**
          * @brief set the output velocity of the motors
          *
@@ -355,6 +365,20 @@ class MotorGroup : public Encoder {
          */
         int setOutputVelocity(AngularVelocity outputVelocity);
         /**
+         * @brief Get the output velocity of the motor group
+         *
+         * @return AngularVelocity the output velocity of the motor group
+         *
+         * @b Example:
+         * @code {.cpp}
+         * void initialize() {
+         *     lemlib::MotorGroup motorGroup({1, -2, 3}, 360_rpm);
+         *     std::cout << "output velocity: " << motorGroup.getOutputVelocity() << std::endl; // outputs 360 rpm
+         * }
+         * @endcode
+         */
+        AngularVelocity getOutputVelocity() const;
+        /**
          * @brief Get the number of connected motors in the group
          *
          * @return int the number of connected motors in the group
@@ -368,7 +392,7 @@ class MotorGroup : public Encoder {
          * }
          * @endcode
          */
-        int getSize();
+        int getSize() const;
         /**
          * @brief Add a motor to the motor group
          *
@@ -506,8 +530,7 @@ class MotorGroup : public Encoder {
          * @return 0 on success
          * @return INT_MAX on failure, setting errno
          */
-        Angle configureMotor(ReversibleSmartPort port);
-        BrakeMode m_brakeMode = BrakeMode::COAST;
+        Angle configureMotor(ReversibleSmartPort port) const;
         /**
          * @brief Get motors in the motor group as a vector of lemlib::Motor objects
          *
@@ -515,7 +538,18 @@ class MotorGroup : public Encoder {
          *
          * @return const std::vector<Motor> vector of lemlib::Motor objects
          */
-        const std::vector<Motor> getMotors();
+        const std::vector<Motor> getMotors() const;
+        /**
+         * @brief Get the Motor Infos
+         *
+         * This function exists to make the copy constructor thread-safe
+         *
+         * @return const std::vector<MotorInfo>
+         */
+        const std::vector<MotorInfo> getMotorInfo() const;
+
+        pros::Mutex m_mutex;
+        BrakeMode m_brakeMode = BrakeMode::COAST;
         AngularVelocity m_outputVelocity;
         /**
          * This member variable is a vector of motor information
@@ -531,6 +565,6 @@ class MotorGroup : public Encoder {
          * It also contains the offset of each motor. This needs to be saved by the motor group, because it can't be
          * saved in a motor object, as motor objects are not saved as member variables
          */
-        std::vector<MotorInfo> m_motors;
+        mutable std::vector<MotorInfo> m_motors;
 };
 }; // namespace lemlib

--- a/include/hardware/Motor/MotorGroup.hpp
+++ b/include/hardware/Motor/MotorGroup.hpp
@@ -548,7 +548,7 @@ class MotorGroup : public Encoder {
          */
         const std::vector<MotorInfo> getMotorInfo() const;
 
-        pros::Mutex m_mutex;
+        mutable pros::Mutex m_mutex;
         BrakeMode m_brakeMode = BrakeMode::COAST;
         AngularVelocity m_outputVelocity;
         /**

--- a/src/hardware/Encoder/ADIEncoder.cpp
+++ b/src/hardware/Encoder/ADIEncoder.cpp
@@ -14,7 +14,7 @@ ADIEncoder::ADIEncoder(ADIPair ports, bool reversed)
 ADIEncoder::ADIEncoder(SmartPort expanderPort, ADIPair ports, bool reversed)
     : m_encoder({expanderPort, ports.first(), ports.second()}, reversed) {}
 
-ADIEncoder::ADIEncoder(ADIEncoder& other)
+ADIEncoder::ADIEncoder(const ADIEncoder& other)
     : m_encoder(other.m_encoder),
       m_offset(other.m_offset) {}
 

--- a/src/hardware/Encoder/ADIEncoder.cpp
+++ b/src/hardware/Encoder/ADIEncoder.cpp
@@ -14,6 +14,10 @@ ADIEncoder::ADIEncoder(ADIPair ports, bool reversed)
 ADIEncoder::ADIEncoder(SmartPort expanderPort, ADIPair ports, bool reversed)
     : m_encoder({expanderPort, ports.first(), ports.second()}, reversed) {}
 
+ADIEncoder::ADIEncoder(ADIEncoder& other)
+    : m_encoder(other.m_encoder),
+      m_offset(other.m_offset) {}
+
 int ADIEncoder::isConnected() {
     // it's not possible to check if the ADIEncoder is connected, so we just return 1 to indicate that it is
     // we do run a simple test however to check if the ports are valid

--- a/src/hardware/Encoder/ADIEncoder.cpp
+++ b/src/hardware/Encoder/ADIEncoder.cpp
@@ -2,6 +2,7 @@
 #include "hardware/Port.hpp"
 #include <cmath>
 #include <limits.h>
+#include <mutex>
 
 namespace lemlib {
 ADIEncoder::ADIEncoder(pros::adi::Encoder encoder)
@@ -25,6 +26,7 @@ int ADIEncoder::isConnected() {
 }
 
 Angle ADIEncoder::getAngle() {
+    std::unique_lock lock(m_mutex);
     const int raw = m_encoder.get_value();
     // check for errors
     if (raw == INT_MAX) {
@@ -36,6 +38,7 @@ Angle ADIEncoder::getAngle() {
 }
 
 int ADIEncoder::setAngle(Angle angle) {
+    std::unique_lock lock(m_mutex);
     // the Vex SDK does not support setting the relative angle of an ADI encoder to a specific value
     // but we can overcome this limitation by resetting the relative angle to zero and saving an offset
     m_offset = angle;

--- a/src/hardware/Encoder/V5RotationSensor.cpp
+++ b/src/hardware/Encoder/V5RotationSensor.cpp
@@ -12,7 +12,7 @@ V5RotationSensor::V5RotationSensor(ReversibleSmartPort port)
     pros::c::rotation_set_reversed(m_port, m_reversed);
 }
 
-V5RotationSensor::V5RotationSensor(V5RotationSensor& other)
+V5RotationSensor::V5RotationSensor(const V5RotationSensor& other)
     : m_port(other.m_port),
       m_reversed(other.m_reversed),
       m_offset(other.m_offset) {}

--- a/src/hardware/Encoder/V5RotationSensor.cpp
+++ b/src/hardware/Encoder/V5RotationSensor.cpp
@@ -3,6 +3,7 @@
 #include "hardware/util.hpp"
 #include "pros/rotation.hpp"
 #include <limits.h>
+#include <mutex>
 
 namespace lemlib {
 V5RotationSensor::V5RotationSensor(ReversibleSmartPort port)
@@ -10,6 +11,11 @@ V5RotationSensor::V5RotationSensor(ReversibleSmartPort port)
       m_reversed(port < 0) {
     pros::c::rotation_set_reversed(m_port, m_reversed);
 }
+
+V5RotationSensor::V5RotationSensor(V5RotationSensor& other)
+    : m_port(other.m_port),
+      m_reversed(other.m_reversed),
+      m_offset(other.m_offset) {}
 
 V5RotationSensor V5RotationSensor::from_pros_rot(pros::Rotation encoder) {
     if (encoder.get_reversed()) return V5RotationSensor {{-encoder.get_port(), runtime_check_port}};
@@ -23,6 +29,7 @@ int V5RotationSensor::isConnected() {
 }
 
 Angle V5RotationSensor::getAngle() {
+    std::lock_guard lock(m_mutex);
     if (pros::c::rotation_set_reversed(m_port, m_reversed) == INT_MAX) return from_stRot(INFINITY);
     const int32_t raw = pros::c::rotation_get_position(m_port);
     if (raw == INT_MAX) return from_stRot(INFINITY);
@@ -32,6 +39,7 @@ Angle V5RotationSensor::getAngle() {
 }
 
 int V5RotationSensor::setAngle(Angle angle) {
+    std::lock_guard lock(m_mutex);
     if (pros::c::rotation_set_reversed(m_port, m_reversed) == INT_MAX) return INT_MAX;
     // requestedAngle = pos + offset
     // offset = requestedAngle - raw
@@ -43,9 +51,13 @@ int V5RotationSensor::setAngle(Angle angle) {
     return 0;
 }
 
-int V5RotationSensor::isReversed() const { return m_reversed; }
+int V5RotationSensor::isReversed() const {
+    std::lock_guard lock(m_mutex);
+    return m_reversed;
+}
 
 int V5RotationSensor::setReversed(bool reversed) {
+    std::lock_guard lock(m_mutex);
     m_reversed = reversed;
     return convertStatus(pros::c::rotation_set_reversed(m_port, m_reversed));
 }

--- a/src/hardware/IMU/V5InertialSensor.cpp
+++ b/src/hardware/IMU/V5InertialSensor.cpp
@@ -7,7 +7,7 @@ namespace lemlib {
 V5InertialSensor::V5InertialSensor(SmartPort port)
     : m_imu(port) {}
 
-V5InertialSensor::V5InertialSensor(V5InertialSensor& other)
+V5InertialSensor::V5InertialSensor(const V5InertialSensor& other)
     : m_imu(other.m_imu),
       m_offset(other.m_offset) {}
 

--- a/src/hardware/IMU/V5InertialSensor.cpp
+++ b/src/hardware/IMU/V5InertialSensor.cpp
@@ -1,16 +1,22 @@
 #include "hardware/IMU/V5InertialSensor.hpp"
 #include "hardware/Port.hpp"
 #include "pros/imu.hpp"
+#include <mutex>
 
 namespace lemlib {
 V5InertialSensor::V5InertialSensor(SmartPort port)
     : m_imu(port) {}
+
+V5InertialSensor::V5InertialSensor(V5InertialSensor& other)
+    : m_imu(other.m_imu),
+      m_offset(other.m_offset) {}
 
 V5InertialSensor V5InertialSensor::from_pros_imu(pros::IMU imu) {
     return V5InertialSensor {{imu.get_port(), runtime_check_port}};
 }
 
 int V5InertialSensor::calibrate() {
+    std::lock_guard lock(m_mutex);
     m_offset = 0_stRot;
     return m_imu.reset();
 }
@@ -22,6 +28,7 @@ int V5InertialSensor::isCalibrating() { return m_imu.is_calibrating(); }
 int V5InertialSensor::isConnected() { return m_imu.is_installed(); }
 
 Angle V5InertialSensor::getRotation() {
+    std::lock_guard lock(m_mutex);
     const double result = m_imu.get_rotation();
     // check for errors
     if (result == INFINITY) return from_stDeg(INFINITY);
@@ -29,6 +36,7 @@ Angle V5InertialSensor::getRotation() {
 }
 
 int V5InertialSensor::setRotation(Angle rotation) {
+    std::lock_guard lock(m_mutex);
     Angle raw = this->getRotation();
     if (to_stRot(raw) == INFINITY) return INT32_MAX;
     else {
@@ -38,9 +46,13 @@ int V5InertialSensor::setRotation(Angle rotation) {
 }
 
 int V5InertialSensor::setGyroScalar(Number scalar) {
+    std::lock_guard lock(m_mutex);
     m_gyroScalar = scalar;
     return 0;
 }
 
-Number V5InertialSensor::getGyroScalar() { return m_gyroScalar; }
+Number V5InertialSensor::getGyroScalar() {
+    std::lock_guard lock(m_mutex);
+    return m_gyroScalar;
+}
 } // namespace lemlib

--- a/src/hardware/Motor/Motor.cpp
+++ b/src/hardware/Motor/Motor.cpp
@@ -14,7 +14,7 @@ Motor::Motor(ReversibleSmartPort port, AngularVelocity outputVelocity)
     : m_port(port),
       m_outputVelocity(outputVelocity) {}
 
-Motor::Motor(Motor& other)
+Motor::Motor(const Motor& other)
     : m_port(other.m_port),
       m_outputVelocity(other.m_outputVelocity),
       m_offset(other.m_offset) {}

--- a/src/hardware/Motor/Motor.cpp
+++ b/src/hardware/Motor/Motor.cpp
@@ -7,11 +7,17 @@
 #include "units/Temperature.hpp"
 #include "units/units.hpp"
 #include <cstdint>
+#include <mutex>
 
 namespace lemlib {
 Motor::Motor(ReversibleSmartPort port, AngularVelocity outputVelocity)
     : m_port(port),
       m_outputVelocity(outputVelocity) {}
+
+Motor::Motor(Motor& other)
+    : m_port(other.m_port),
+      m_outputVelocity(other.m_outputVelocity),
+      m_offset(other.m_offset) {}
 
 Motor Motor::from_pros_motor(const pros::Motor motor, AngularVelocity outputVelocity) {
     return Motor {{motor.get_port(), runtime_check_port}, outputVelocity};
@@ -51,6 +57,7 @@ int Motor::move(Number percent) {
 }
 
 int Motor::moveVelocity(AngularVelocity velocity) {
+    std::lock_guard lock(m_mutex);
     // vexos will behave differently depending on the cartridge of the motor
     // pros uses an integer value to represent the rpm of the motor
     const pros::motor_gearset_e_t mode = pros::c::motor_get_gearing(m_port);
@@ -74,9 +81,13 @@ int Motor::moveVelocity(AngularVelocity velocity) {
     return convertStatus(pros::c::motor_move_velocity(m_port, out));
 }
 
-int Motor::brake() { return convertStatus(pros::c::motor_brake(m_port)); }
+int Motor::brake() {
+    std::lock_guard lock(m_mutex);
+    return convertStatus(pros::c::motor_brake(m_port));
+}
 
 int Motor::setBrakeMode(BrakeMode mode) {
+    std::lock_guard lock(m_mutex);
     if (mode == BrakeMode::INVALID) {
         errno = EINVAL;
         return INT_MAX;
@@ -84,11 +95,15 @@ int Motor::setBrakeMode(BrakeMode mode) {
     return convertStatus(pros::c::motor_set_brake_mode(m_port, brakeModeToMotorBrake(mode)));
 }
 
-BrakeMode Motor::getBrakeMode() const { return motorBrakeToBrakeMode(pros::c::motor_get_brake_mode(m_port)); }
+BrakeMode Motor::getBrakeMode() const {
+    std::lock_guard lock(m_mutex);
+    return motorBrakeToBrakeMode(pros::c::motor_get_brake_mode(m_port));
+}
 
 int Motor::isConnected() { return pros::c::get_plugged_type(m_port) == pros::c::v5_device_e_t::E_DEVICE_MOTOR; }
 
 Angle Motor::getAngle() {
+    std::lock_guard lock(m_mutex);
     // get the number of encoder ticks
     const int ticks = pros::c::motor_get_raw_position(m_port, NULL);
     if (ticks == INT_MAX) return from_stRot(INFINITY);
@@ -101,6 +116,7 @@ Angle Motor::getAngle() {
 }
 
 int Motor::setAngle(Angle angle) {
+    std::lock_guard lock(m_mutex);
     // get the raw position
     const int ticks = pros::c::motor_get_raw_position(m_port, NULL);
     if (ticks == INT_MAX) return INT_MAX;
@@ -113,14 +129,19 @@ int Motor::setAngle(Angle angle) {
     return 0;
 }
 
-Angle Motor::getOffset() const { return m_offset; }
+Angle Motor::getOffset() const {
+    std::lock_guard lock(m_mutex);
+    return m_offset;
+}
 
 int Motor::setOffset(Angle offset) {
+    std::lock_guard lock(m_mutex);
     m_offset = offset;
     return 0;
 }
 
 MotorType Motor::getType() {
+    std::lock_guard lock(m_mutex);
     // there is no exposed api to get the motor type
     // while the memory address of the function has been found through reverse engineering,
     // it may break between VEXos updates. Instead, we see if we can change the cartridge to something other
@@ -141,27 +162,36 @@ MotorType Motor::getType() {
 }
 
 int Motor::isReversed() const {
+    std::lock_guard lock(m_mutex);
     // technically this returns an int, but as long as you only pass 0 to the index its impossible for it to return an
     // error. This is because we keep track of whether the motor is reversed or not through the sign of its port
     return m_port < 0;
 }
 
 int Motor::setReversed(bool reversed) {
+    std::lock_guard lock(m_mutex);
     // technically this returns an int, but as long as you only pass 0 to the index its impossible for it to return an
     // error. This is because we keep track of whether the motor is reversed or not through the sign of its port
     m_port = m_port.set_reversed(reversed);
     return 0;
 }
 
-ReversibleSmartPort Motor::getPort() const { return m_port; }
+ReversibleSmartPort Motor::getPort() const {
+    std::lock_guard lock(m_mutex);
+    return m_port;
+}
 
 Current Motor::getCurrentLimit() const {
+    std::lock_guard lock(m_mutex);
     const Current result = from_amp(pros::c::motor_get_current_limit(m_port));
     if (result.internal() == INT32_MAX) return from_amp(INFINITY); // error checking
     return result;
 }
 
-int Motor::setCurrentLimit(Current limit) { return pros::c::motor_set_current_limit(m_port, to_amp(limit) * 1000); }
+int Motor::setCurrentLimit(Current limit) {
+    std::lock_guard lock(m_mutex);
+    return pros::c::motor_set_current_limit(m_port, to_amp(limit) * 1000);
+}
 
 Temperature Motor::getTemperature() const {
     const Temperature result = units::from_celsius(pros::c::motor_get_temperature(m_port));
@@ -171,9 +201,15 @@ Temperature Motor::getTemperature() const {
 
 // Always returns 0 because the velocity setter is not dependent on hardware and should never fail
 int Motor::setOutputVelocity(AngularVelocity outputVelocity) {
+    std::lock_guard lock(m_mutex);
     Angle angle = getAngle();
     m_outputVelocity = outputVelocity;
     setAngle(angle);
     return 0;
+}
+
+AngularVelocity Motor::getOutputVelocity() {
+    std::lock_guard lock(m_mutex);
+    return m_outputVelocity;
 }
 } // namespace lemlib


### PR DESCRIPTION
#### Overview
make all hardware classes thread safe

#### Motivation
prevents weird behavior when the scheduler is overloaded

#### Implementation
used `std::lock_guard` along with `pros::Mutex`. Copy constructors are now explicit because pros::Mutex does not have a copy constructor, and the copy constructor should be thread safe

#### Testing
- [ ] ADIEncoder can't get mutex locked indefinitely
- [ ] V5RotationSensor can't get mutex locked indefinitely
- [ ] V5InertialSensor can't get mutex locked indefinitely
- [ ] Motor can't get mutex locked indefinitely
- [ ] MotorGroup can't get mutex locked indefinitely
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: 4ee4737569fec704d93ff65329816aa00ff64768 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/hardware/actions/runs/12839540128)
- via manual download: [hardware@0.4.2+4ee473.zip](https://nightly.link/LemLib/hardware/actions/artifacts/2450021542.zip)
- via PROS Integrated Terminal: 
 ```
curl -o hardware@0.4.2+4ee473.zip https://nightly.link/LemLib/hardware/actions/artifacts/2450021542.zip;
pros c fetch hardware@0.4.2+4ee473.zip;
pros c apply hardware@0.4.2+4ee473;
rm hardware@0.4.2+4ee473.zip;
```