### PR TITLE
:bug: fix getAngle for motor groups

### DIFF
--- a/src/hardware/Motor/MotorGroup.cpp
+++ b/src/hardware/Motor/MotorGroup.cpp
@@ -109,7 +109,7 @@ Angle MotorGroup::getAngle() const {
     // if no motors are connected, return INFINITY
     if (errors == motors.size()) return from_stDeg(INFINITY);
     // otherwise, return the average angle
-    return angle / (getSize() - errors);
+    return angle / (motors.size() - errors);
 }
 
 int32_t MotorGroup::setAngle(Angle angle) {


### PR DESCRIPTION
``getSize`` tries to claim the mutex which is already claimed by ``getAngle`` causing a deadlock
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: f8f46ca80c881eed61715d2f493f65f345e1d861 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/hardware/actions/runs/13081130581)
- via manual download: [hardware@0.4.2+39214b.zip](https://nightly.link/LemLib/hardware/actions/artifacts/2519451072.zip)
- via PROS Integrated Terminal: 
 ```
curl -o hardware@0.4.2+39214b.zip https://nightly.link/LemLib/hardware/actions/artifacts/2519451072.zip;
pros c fetch hardware@0.4.2+39214b.zip;
pros c apply hardware@0.4.2+39214b;
rm hardware@0.4.2+39214b.zip;
```