### PR TITLE
add missing files to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ EXCLUDE_SRC_FROM_LIB+=$(foreach file, $(SRCDIR)/main,$(foreach cext,$(CEXTS),$(f
 # files that get distributed to every user (beyond your source archive) - add
 # whatever files you want here. This line is configured to add all header files
 # that are in the directory include/LIBNAME
-TEMPLATE_FILES=$(INCDIR)/$(LIBNAME)/Port.hpp $(INCDIR)/$(LIBNAME)/Encoder/*.hpp $(INCDIR)/$(LIBNAME)/IMU/*.hpp $(INCDIR)/$(LIBNAME)/Motor/*.hpp
+TEMPLATE_FILES=$(INCDIR)/$(LIBNAME)/Port.hpp $(INCDIR)/$(LIBNAME)/Device.hpp $(INCDIR)/$(LIBNAME)/util.hpp $(INCDIR)/$(LIBNAME)/Encoder/*.hpp $(INCDIR)/$(LIBNAME)/IMU/*.hpp $(INCDIR)/$(LIBNAME)/Motor/*.hpp
 
 .DEFAULT_GOAL=quick
 


### PR DESCRIPTION
``Device.hpp`` and ``util.hpp`` were not included in the makefile
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: e9ac4589680615910ceb13866e53870951c6e293 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/hardware/actions/runs/13088929520)
- via manual download: [hardware@0.4.2+925ed2.zip](https://nightly.link/LemLib/hardware/actions/artifacts/2521212506.zip)
- via PROS Integrated Terminal: 
 ```
curl -o hardware@0.4.2+925ed2.zip https://nightly.link/LemLib/hardware/actions/artifacts/2521212506.zip;
pros c fetch hardware@0.4.2+925ed2.zip;
pros c apply hardware@0.4.2+925ed2;
rm hardware@0.4.2+925ed2.zip;
```