### PR TITLE
✨ Add getPort to inertial sensor

### DIFF
--- a/include/hardware/IMU/V5InertialSensor.hpp
+++ b/include/hardware/IMU/V5InertialSensor.hpp
@@ -47,20 +47,20 @@ class V5InertialSensor : public IMU {
          */
         static V5InertialSensor from_pros_imu(pros::Imu imu, Number scalar = 1.0);
         /**
-        * @brief Get the port the inertial sensor is connected to
-        *
-        * This function returns the port number of the inertial sensor.
-        *
-        * @return SmartPort the port the inertial sensor is connected to
-        *
-        * @b Example:
-        * @code {.cpp}
-        * void initialize() {
-        *     lemlib::V5InertialSensor imu(1);
-        *     std::cout << "Inertial sensor is connected to port " << imu.getPort() << std::endl;
-        * }
-        * @endcode
-        */
+         * @brief Get the port the inertial sensor is connected to
+         *
+         * This function returns the port number of the inertial sensor.
+         *
+         * @return SmartPort the port the inertial sensor is connected to
+         *
+         * @b Example:
+         * @code {.cpp}
+         * void initialize() {
+         *     lemlib::V5InertialSensor imu(1);
+         *     std::cout << "Inertial sensor is connected to port " << imu.getPort() << std::endl;
+         * }
+         * @endcode
+         */
         SmartPort getPort() const;
         /**
          * @brief calibrate the V5 Inertial Sensor

--- a/include/hardware/IMU/V5InertialSensor.hpp
+++ b/include/hardware/IMU/V5InertialSensor.hpp
@@ -47,6 +47,22 @@ class V5InertialSensor : public IMU {
          */
         static V5InertialSensor from_pros_imu(pros::Imu imu, Number scalar = 1.0);
         /**
+        * @brief Get the port the inertial sensor is connected to
+        *
+        * This function returns the port number of the inertial sensor.
+        *
+        * @return SmartPort the port the inertial sensor is connected to
+        *
+        * @b Example:
+        * @code {.cpp}
+        * void initialize() {
+        *     lemlib::V5InertialSensor imu(1);
+        *     std::cout << "Inertial sensor is connected to port " << imu.getPort() << std::endl;
+        * }
+        * @endcode
+        */
+        SmartPort getPort() const;
+        /**
          * @brief calibrate the V5 Inertial Sensor
          *
          * This function calibrates the IMU. Calibrating the IMU is needed before it can be used.

--- a/src/hardware/IMU/V5InertialSensor.cpp
+++ b/src/hardware/IMU/V5InertialSensor.cpp
@@ -20,7 +20,7 @@ V5InertialSensor V5InertialSensor::from_pros_imu(pros::IMU imu, Number scalar) {
 
 SmartPort V5InertialSensor::getPort() const {
     std::lock_guard lock(m_mutex);
-    SmartPort port(m_imu.get_port(),DynamicPort{});
+    SmartPort port(m_imu.get_port(), DynamicPort {});
     return port;
 }
 

--- a/src/hardware/IMU/V5InertialSensor.cpp
+++ b/src/hardware/IMU/V5InertialSensor.cpp
@@ -1,6 +1,7 @@
 #include "hardware/IMU/V5InertialSensor.hpp"
 #include "hardware/Port.hpp"
 #include "pros/imu.hpp"
+#include <cstdint>
 #include <mutex>
 
 namespace lemlib {
@@ -15,6 +16,12 @@ V5InertialSensor::V5InertialSensor(const V5InertialSensor& other)
 
 V5InertialSensor V5InertialSensor::from_pros_imu(pros::IMU imu, Number scalar) {
     return V5InertialSensor({imu.get_port(), runtime_check_port}, scalar);
+}
+
+SmartPort V5InertialSensor::getPort() const {
+    std::lock_guard lock(m_mutex);
+    SmartPort port(m_imu.get_port(),DynamicPort{});
+    return port;
 }
 
 int32_t V5InertialSensor::calibrate() {


### PR DESCRIPTION
allows user to use the pros::c functions functions to access all of the missing functionality from the inertial sensor
<!-- DO NOT REMOVE!! -->
<!-- bot: nightly-link -->
<!-- commit-sha: c6a4e780400d3c4efd307269c3c93bbc0bb70e30 -->
## Download the template for this pull request: 

> [!NOTE]  
> This is auto generated from [`Add Template to Pull Request`](https://github.com/LemLib/hardware/actions/runs/14432767823)
- via manual download: [hardware@0.4.2+e13077.zip](https://nightly.link/LemLib/hardware/actions/artifacts/2935814394.zip)
- via PROS Integrated Terminal: 
 ```
curl -o hardware@0.4.2+e13077.zip https://nightly.link/LemLib/hardware/actions/artifacts/2935814394.zip;
pros c fetch hardware@0.4.2+e13077.zip;
pros c apply hardware@0.4.2+e13077;
rm hardware@0.4.2+e13077.zip;
```